### PR TITLE
Improve support for reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Explanation for each field:
     "blocks": 30, //amount of blocks to send at a time
     "payments": 30, //amount of payments to send at a time
     "password": "test" //password required for admin stats
+    "trust_proxy_ip": false //trust the X-Forwarded-For header to set the client IP. This should be used in combination with reverse proxies.
 },
 
 /* Coin daemon connection details. */

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -103,7 +103,8 @@
         "port": 8118,
         "blocks": 30,
         "payments": 30,
-        "password": "your_password"
+        "password": "your_password",
+        "trust_proxy_ip: false
     },
 
     "daemon": {

--- a/lib/api.js
+++ b/lib/api.js
@@ -344,7 +344,13 @@ function parseCookies(request) {
 }
 
 function authorize(request, response){
-    if(request.connection.remoteAddress == '127.0.0.1' || request.connection.remoteAddress == '::ffff:127.0.0.1' || request.connection.remoteAddress == '::1') {
+
+    var remoteAddress = request.connection.remoteAddress;
+    if (config.api.trust_proxy_ip && request.headers['x-forwarded-for']) {
+      remoteAddress = request.headers['x-forwarded-for'];
+    }
+
+    if(remoteAddress == '127.0.0.1' || remoteAddress == '::ffff:127.0.0.1' || remoteAddress == '::1') {
         return true;
     }
 
@@ -491,6 +497,21 @@ function handleAdminUsers(response){
         }
     );
 }
+
+function handleHealthRequest(response) {
+    response.writeHead("200", {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json'
+    });
+    async.parallel({
+        monitoring: getMonitoringData,
+        logs: getLogFiles
+    }, function(error, result) {
+        response.end(JSON.stringify(result));
+    });
+}
+
 
 
 function handleAdminMonitoring(response) {


### PR DESCRIPTION
When you run the pool behind a reverse proxy; the authorization logic will
think every requests comes from 127.0.0.1 and will leave the /admin.html
interface open to everyone.

Using this feature, the API can be configured to take the client IP from
the X-Forwarded-For header rather than the IP from which the connection
originates.