### PR TITLE
Allow pool health to be monitoring by miners 

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -521,6 +521,23 @@ function handleAdminLog(urlParts, response){
     fs.createReadStream(filePath).pipe(response);
 }
 
+function handleHealthRequest(response) {
+    response.writeHead("200", {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json'
+    });
+    async.parallel({
+        monitoring: getMonitoringData
+    }, function(error, result) {
+        var status = 'NOT OK';
+	if (result['monitoring']['daemon']['lastStatus'] == "ok" &&
+            result['monitoring']['wallet']['lastStatus'] == "ok") {
+            status = 'OK';
+        }
+        response.end(JSON.stringify({"status": status}));
+    });
+}
 
 function startRpcMonitoring(rpc, module, method, interval) {
     setInterval(function() {
@@ -625,6 +642,9 @@ if(config.api.ssl == true)
       var urlParts = url.parse(request.url, true);
 
       switch(urlParts.pathname){
+          case '/health':
+              handleHealthRequest(response);
+              break;
           case '/stats':
               var deflate = request.headers['accept-encoding'] && request.headers['accept-encoding'].indexOf('deflate') != -1;
               var reply = deflate ? currentStatsCompressed : currentStats;
@@ -726,6 +746,9 @@ var server = http.createServer(function(request, response){
     var urlParts = url.parse(request.url, true);
 
     switch(urlParts.pathname){
+        case '/health':
+            handleHealthRequest(response);
+            break;
         case '/stats':
             var deflate = request.headers['accept-encoding'] && request.headers['accept-encoding'].indexOf('deflate') != -1;
             var reply = deflate ? currentStatsCompressed : currentStats;

--- a/website/index.html
+++ b/website/index.html
@@ -278,6 +278,24 @@
         });
     }
 
+    function fetchHealthState() {
+        $.ajax({
+            url: api + '/health',
+            dataType: 'json',
+            cache: 'false'
+        }).done(function(data){
+            if (data.status == "OK") {
+	        $('#health_warning').hide(100);
+	    } else {
+	        $('#health_warning').show(100);
+            }
+        });
+    }
+    // Every 5 seconds check the health status.
+    setInterval(fetchHealthState, 5000);
+    fetchHealthState();
+
+
     function floatToString(float) {
         return float.toFixed(6).replace(/[0\.]+$/, '');
     }
@@ -385,6 +403,9 @@
 </div>
 
 <footer>
+    <div id="health_warning">
+        This pool is not healthy! Contact the admin for support.
+    </div>
     <div class="text-muted">
         Powered by <a target="_blank" href="//cryptonotemining.org"><i class="fa fa-github"></i> cryptonote-universal-pool</a>
         <span id="poolVersion"></span>

--- a/website/themes/deep-gray-dark-theme.css
+++ b/website/themes/deep-gray-dark-theme.css
@@ -245,3 +245,8 @@ a.list-group-item.active:focus {
 .nav-pills > li.active > a:focus {
   background-color: #6d6d6d;
 }
+
+#health_warning {
+  color: red;
+  font-size: large;
+}

--- a/website/themes/default-theme.css
+++ b/website/themes/default-theme.css
@@ -221,3 +221,7 @@ a.list-group-item.active:focus {
   background-color: #777;
 }
 
+#health_warning {
+  color: red;
+  font-size: large;
+}

--- a/website/themes/ease-way-light-theme.css
+++ b/website/themes/ease-way-light-theme.css
@@ -246,3 +246,7 @@ a.list-group-item.active:focus {
   background-color: #0088aa;
 }
 
+#health_warning {
+  color: red;
+  font-size: large;
+}

--- a/website/themes/motherboard-dark-theme.css
+++ b/website/themes/motherboard-dark-theme.css
@@ -246,3 +246,8 @@ a.list-group-item.active:focus {
   color: #fff;
   background-color: #00863b;
 }
+
+#health_warning {
+  color: red;
+  font-size: large;
+}

--- a/website/themes/nightly-mining-dark-theme.css
+++ b/website/themes/nightly-mining-dark-theme.css
@@ -245,3 +245,8 @@ a.list-group-item.active:focus {
   color: #fff;
   background-color: #1f94b1;
 }
+
+#health_warning {
+  color: red;
+  font-size: large;
+}


### PR DESCRIPTION
Adds a /health handler which returns OK if the wallet and sumokoind deamons 
are reachable.

This handler makes it more transparent to miners whether a pool is in
fact healthy: It is possible today that a pool server gives work to
miners without having a wallet RPC daemon running in the background.
In this case the miners will go unpaid until the admin fixes this.

This handler allows miner software, and also sites like sumopools.com,
to check the health of the pool.