### PR TITLE
Add an SSL protected port for all existing (plain text) ports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ Explanation for each field:
             "port": 3335,
             "difficulty": 20000,
             "desc": "High end hardware"
+        },
+        {
+            "port": 3336,
+            "difficulty": 20000,
+            "desc": "High end hardware (SSL protected)",
+            /* When you enable SSL; the server expects that you put the
+               SSL key and cert as the files "key.pem" and "cert.pem" into the
+               directory from which you run the pool server. /*
+            "type": "SSL"
         }
     ],
 

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -29,9 +29,21 @@
                 "desc": "Low end hardware"
             },
             {
+                "port": 3334,
+                "difficulty": 2000,
+                "desc": "Low end hardware (SSL protected)",
+                "type": "SSL"
+            },
+            {
                 "port": 4444,
                 "difficulty": 10000,
                 "desc": "Mid range hardware"
+            },
+            {
+                "port": 4445,
+                "difficulty": 10000,
+                "desc": "Mid range hardware (SSL protected)",
+                "type": "SSL"
             },
             {
                 "port": 5555,
@@ -39,11 +51,24 @@
                 "desc": "High end hardware"
             },
             {
+                "port": 5555,
+                "difficulty": 20000,
+                "desc": "High end hardware (SSL protected)",
+                "type": "SSL"
+            },
+            {
                 "port": 6666,
                 "difficulty": 30000,
                 "desc": "Hidden port",
                 "hidden": true
-            }
+            },
+            {
+                "port": 6667,
+                "difficulty": 30000,
+                "desc": "Hidden port (SSL protected)",
+                "hidden": true,
+                "type": "SSL"
+            },
         ],
         "varDiff": {
             "minDiff": 2000,


### PR DESCRIPTION
By default the ports are plaintext which isn't good for privacy. I think it's good for pool.sumokoin.com to set the example and have SSL ports.  

This change also updated the example configuration in README.md so that it's clear that this option is available _and_ where you need to put the cert/key.

----- IMPORTANT IMPORTANT IMPORTANT
This change requires an "key.pem" and "cert.pem" file to be present in the directory where you start the pool. 

The SSL cert/key locations are not configurable at the moment and loaded from here:
https://github.com/sumoprojects/cryptonote-sumokoin-pool/blob/master/lib/pool.js#L791 