### PR TITLE
New settings page and email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Explanation for each field:
     "denomination": 10000000, //truncate to this precision and store remainder
 	"useDynamicTransferFee": true, // use (simple) dynamic transfer fee
 	"transferFeePerPayee": 4000000, // dynamic transfer fee per payee/transaction
-	"minerPayFee": true // miner pays (dynamic) transfer fee instead of pool owner 
+	"minerPayFee": true // miner pays (dynamic) transfer fee instead of pool owner
 },
 
 /* Module that monitors the submitted block maturities and manages rounds. Confirmed
@@ -295,6 +295,17 @@ Explanation for each field:
     "host": "127.0.0.1",
     "port": 6379
 }
+
+/* Email configuration */
+"email": {
+  "enabled": false,
+  "api_key": "",                 // Your Mailgun.com API key.
+  "api_domain": "mg.yourdomain", // The domain you registered at Mailgun.
+  "from_address": "",            // The email address to which users can reply.
+  "template_dir": "email_templates",
+  "domain": "pool.domain.here"   // Used for links in the email.
+},
+
 
 /* Monitoring RPC services. Statistics will be displayed in Admin panel */
 "monitoring": {
@@ -457,8 +468,8 @@ the Node.js modules, and any config files that may have been changed.
 ### Setting up Testnet
 
 Monero does have a testnet. Call daemon and simplewallet with --tesnet to connect to it.
-Downloading the testnet blockchain may still take a while to start usint testnet, so you can use this excellent 
-tutorial http://moneroexamples.github.io/private-testnet/ to set up a private testnet. Should work with other 
+Downloading the testnet blockchain may still take a while to start usint testnet, so you can use this excellent
+tutorial http://moneroexamples.github.io/private-testnet/ to set up a private testnet. Should work with other
 coins, too, but below are original testnet instructions by server43 for reference, too.
 
 For cryptonote based coins that don't have a testnet mode (yet), you can effectively create a testnet with the following steps:
@@ -506,8 +517,8 @@ Credits
 * [wallet42](http://moneropool.com) - Funded development of payment denominating and min threshold feature
 * [Wolf0](https://bitcointalk.org/index.php?action=profile;u=80740) - Helped try to deobfuscate some of the daemon code for getting a bug fixed
 * [Tacotime](https://bitcointalk.org/index.php?action=profile;u=19270) - helping with figuring out certain problems and lead the bounty for this project's creation
-* [fancoder] (https://github.com/fancoder) Initial cryptonote-universal-pool creator 
- * BTC: `1667jMt7NTZDaC8WXAxtMYBR8DPWCVoU4d`- 
+* [fancoder] (https://github.com/fancoder) Initial cryptonote-universal-pool creator
+ * BTC: `1667jMt7NTZDaC8WXAxtMYBR8DPWCVoU4d`-
  * MRO: `48Y4SoUJM5L3YXBEfNQ8bFNsvTNsqcH5Rgq8RF7BwpgvTBj2xr7CmWVanaw7L4U9MnZ4AG7U6Pn1pBhfQhFyFZ1rL1efL8z`
 * [clintar] (https://github.com/clintar) Updates to support nodejs >0.10 and continuing updates
 License

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -121,6 +121,10 @@
         "port": 6379
     },
 
+    "email": {
+      "api_key": ""
+    }
+
     "monitoring": {
         "daemon": {
             "checkInterval": 60,

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -128,7 +128,7 @@
       "from_address": "",
       "template_dir": "email_templates",
       "domain": "pool.domain.here"
-    }
+    },
 
     "monitoring": {
         "daemon": {

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -122,7 +122,12 @@
     },
 
     "email": {
-      "api_key": ""
+      "enabled": false,
+      "api_key": "",
+      "api_domain": "mg.yourdomain",
+      "from_address": "",
+      "template_dir": "email_templates",
+      "domain": "pool.domain.here"
     }
 
     "monitoring": {

--- a/email_templates/email_added
+++ b/email_templates/email_added
@@ -1,2 +1,6 @@
-Your email has been setup to receive notifications from the %POOL_HOST%
-pool.
+Your email has been setup to receive notifications from the %POOL_HOST% pool.
+
+You can enable/disable these notifications at any time by visiting the pool's
+web interface at:
+
+https://%POOL_HOST/#notifications

--- a/email_templates/email_added
+++ b/email_templates/email_added
@@ -3,4 +3,4 @@ Your email has been setup to receive notifications from the %POOL_HOST% pool.
 You can enable/disable these notifications at any time by visiting the pool's
 web interface at:
 
-https://%POOL_HOST%/#notifications
+https://%POOL_HOST%/#settings

--- a/email_templates/email_added
+++ b/email_templates/email_added
@@ -3,4 +3,4 @@ Your email has been setup to receive notifications from the %POOL_HOST% pool.
 You can enable/disable these notifications at any time by visiting the pool's
 web interface at:
 
-https://%POOL_HOST/#notifications
+https://%POOL_HOST%/#notifications

--- a/email_templates/email_added
+++ b/email_templates/email_added
@@ -1,0 +1,2 @@
+Your email has been setup to receive notifications from the %POOL_HOST%
+pool.

--- a/email_templates/payment_received
+++ b/email_templates/payment_received
@@ -1,1 +1,3 @@
-You received a payment from your pool %POOL_HOST%.
+Good news ! You received a payment from your pool %POOL_HOST%.
+
+For more information the pool at: https://%POOL_HOST%

--- a/email_templates/payment_received
+++ b/email_templates/payment_received
@@ -1,0 +1,1 @@
+You received a payment from your pool %POOL_HOST%.

--- a/lib/api.js
+++ b/lib/api.js
@@ -287,6 +287,14 @@ function handleSetAddressEmail(urlParts, response){
         return;
     }
 
+    // Do not allow wildcards in the queries.
+    if (ip.indexOf('*') != -1 || address.indexOf('*') != -1) {
+        response.end(JSON.stringify({'status': 'remove the wildcard from your input'}));
+        return;
+    }
+
+    // Now only do a modification if we have seen the IP address in combination
+    // with the wallet address.
     minerSeenWithIPForAddress(address, ip, function (error, keys) {
       if (!keys || error) {
         response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));

--- a/lib/api.js
+++ b/lib/api.js
@@ -286,7 +286,7 @@ function handleSetAddressEmail(urlParts, response){
                 return;
             }
 
-            emailSystem.notifyAddress(address, 'Your email was registered', 'Yeah');
+            emailSystem.notifyAddress(address, 'Your email was registered', 'email_added');
         });
         log('info', logSystem, 'Added email ' + email + ' for address: ' + address);
     } else if (action == "delete") {

--- a/lib/api.js
+++ b/lib/api.js
@@ -296,7 +296,7 @@ function handleSetAddressEmail(urlParts, response){
     // Now only do a modification if we have seen the IP address in combination
     // with the wallet address.
     minerSeenWithIPForAddress(address, ip, function (error, keys) {
-      if (!keys || error) {
+      if (keys.length == 0 || error) {
         response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));
         return;
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -256,6 +256,16 @@ function handleMinerStats(urlParts, response){
     }
 }
 
+/* Check whether we've seen a miner for 'address' using 'ip' */
+function minerSeenWithIPForAddress(address, ip) {
+    var ipv4_regex = /\d{1,3}\.\d{1,3}\d{1,3}\d{1,3}/;
+    if (ipv4_regex.test(ip)) {
+      ip = '::ffff:' + ip;
+    }
+    var keys = redisClient.keys(config.coin + ':unique_workers:' + address + ':*:ip');
+    return (keys != undefined && keys.length > 0);
+}
+
 function handleSetAddressEmail(urlParts, response){
     response.writeHead(200, {
         'Access-Control-Allow-Origin': '*',
@@ -267,7 +277,13 @@ function handleSetAddressEmail(urlParts, response){
 
     var email = urlParts.query.email;
     var address = urlParts.query.address;
+    var ip = urlParts.query.ip;
     var action = urlParts.query.action;
+
+    if (!minerSeenWithIPForAddress(address, ip)) {
+      response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));
+      return;
+    }
 
     // Check the minimal required parameters for this handle.
     if (address == undefined || action == undefined) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -256,14 +256,15 @@ function handleMinerStats(urlParts, response){
     }
 }
 
-/* Check whether we've seen a miner for 'address' using 'ip' */
-function minerSeenWithIPForAddress(address, ip) {
-    var ipv4_regex = /\d{1,3}\.\d{1,3}\d{1,3}\d{1,3}/;
+/* Call 'callback' when we've seen a miner for 'address' using 'ip' */
+function minerSeenWithIPForAddress(address, ip, callback) {
+    var ipv4_regex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
     if (ipv4_regex.test(ip)) {
-      ip = '::ffff:' + ip;
+        ip = '::ffff:' + ip;
     }
-    var keys = redisClient.keys(config.coin + ':unique_workers:' + address + ':*:ip');
-    return (keys != undefined && keys.length > 0);
+    redisClient.keys(config.coin + ':unique_workers:' + address + ':*:' + ip, function(error, keys) {
+          callback(error, keys);
+    });
 }
 
 function handleSetAddressEmail(urlParts, response){
@@ -280,41 +281,43 @@ function handleSetAddressEmail(urlParts, response){
     var ip = urlParts.query.ip;
     var action = urlParts.query.action;
 
-    if (!minerSeenWithIPForAddress(address, ip)) {
-      response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));
-      return;
-    }
-
     // Check the minimal required parameters for this handle.
     if (address == undefined || action == undefined) {
         response.end(JSON.stringify({'status': 'parameters are incomplete'}));
         return;
     }
 
-    if (action == "upsert") {
-        if (email == undefined) {
-            response.end(JSON.stringify({'status': 'email is missing'}));
-            return;
-        }
-        redisClient.hset(config.coin + ':notifications:', address, email, function(error, value){
-            if (error){
-                response.end(JSON.stringify({'status': 'woops something failed'}));
-                return;
-            }
+    minerSeenWithIPForAddress(address, ip, function (error, keys) {
+      if (!keys || error) {
+        response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));
+        return;
+      }
 
-            emailSystem.notifyAddress(address, 'Your email was registered', 'email_added');
-        });
-        log('info', logSystem, 'Added email ' + email + ' for address: ' + address);
-    } else if (action == "delete") {
-        redisClient.hdel(config.coin + ':notifications:', address, function(error, value){
-            if (error){
-                response.end(JSON.stringify({'status': 'woops something failed'}));
-                return;
-            }
-        });
-        log('info', logSystem, 'Removed email for address: ' + address);
-    }
-    response.end(JSON.stringify({'status': 'done'}));
+      if (action == "upsert") {
+          if (email == undefined) {
+              response.end(JSON.stringify({'status': 'email is missing'}));
+              return;
+          }
+          redisClient.hset(config.coin + ':notifications:', address, email, function(error, value){
+              if (error){
+                  response.end(JSON.stringify({'status': 'woops something failed'}));
+                  return;
+              }
+
+              emailSystem.notifyAddress(address, 'Your email was registered', 'email_added');
+          });
+          log('info', logSystem, 'Added email ' + email + ' for address: ' + address);
+      } else if (action == "delete") {
+          redisClient.hdel(config.coin + ':notifications:', address, function(error, value){
+              if (error){
+                  response.end(JSON.stringify({'status': 'woops something failed'}));
+                  return;
+              }
+          });
+          log('info', logSystem, 'Removed email for address: ' + address);
+      }
+      response.end(JSON.stringify({'status': 'done'}));
+  });
 }
 
 function handleGetAddressEmail(urlParts, response){

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,7 +11,7 @@ var charts = require('./charts.js');
 var authSid = Math.round(Math.random() * 10000000000) + '' + Math.round(Math.random() * 10000000000);
 
 var logSystem = 'api';
-var email = require('./email.js');
+var emailSystem = require('./email.js');
 require('./exceptionWriter.js')(logSystem);
 
 var redisCommands = [
@@ -286,7 +286,7 @@ function handleSetAddressEmail(urlParts, response){
                 return;
             }
 
-            email.notifyAddress(address, 'Your email was registered', 'Yeah');
+            emailSystem.notifyAddress(address, 'Your email was registered', 'Yeah');
         });
         log('info', logSystem, 'Added email ' + email + ' for address: ' + address);
     } else if (action == "delete") {

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,7 @@ var charts = require('./charts.js');
 var authSid = Math.round(Math.random() * 10000000000) + '' + Math.round(Math.random() * 10000000000);
 
 var logSystem = 'api';
+var email = require('./email.js');
 require('./exceptionWriter.js')(logSystem);
 
 var redisCommands = [
@@ -253,6 +254,78 @@ function handleMinerStats(urlParts, response){
             });
         });
     }
+}
+
+function handleSetAddressEmail(urlParts, response){
+    response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+        'Connection': 'keep-alive'
+    });
+    response.write('\n');
+
+    var email = urlParts.query.email;
+    var address = urlParts.query.address;
+    var action = urlParts.query.action;
+
+    // Check the minimal required parameters for this handle.
+    if (address == undefined || action == undefined) {
+        response.end(JSON.stringify({'status': 'parameters are incomplete'}));
+        return;
+    }
+
+    if (action == "upsert") {
+        if (email == undefined) {
+            response.end(JSON.stringify({'status': 'email is missing'}));
+            return;
+        }
+        redisClient.hset(config.coin + ':notifications:', address, email, function(error, value){
+            if (error){
+                response.end(JSON.stringify({'status': 'woops something failed'}));
+                return;
+            }
+
+            email.notifyAddress(address, 'Your email was registered', 'Yeah');
+        });
+        log('info', logSystem, 'Added email ' + email + ' for address: ' + address);
+    } else if (action == "delete") {
+        redisClient.hdel(config.coin + ':notifications:', address, function(error, value){
+            if (error){
+                response.end(JSON.stringify({'status': 'woops something failed'}));
+                return;
+            }
+        });
+        log('info', logSystem, 'Removed email for address: ' + address);
+    }
+    response.end(JSON.stringify({'status': 'done'}));
+}
+
+function handleGetAddressEmail(urlParts, response){
+    response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+        'Connection': 'keep-alive'
+    });
+    response.write('\n');
+
+    var address = urlParts.query.address;
+
+    // Check the minimal required parameters for this handle.
+    if (address == undefined) {
+        response.end(JSON.stringify({'status': 'parameters are incomplete'}));
+        return;
+    }
+
+    redisClient.hget(config.coin + ':notifications:', address, function(error, value){
+        if (error){
+            response.end(JSON.stringify({'email': 'woops something failed'}));
+            return;
+        }
+        response.end(JSON.stringify({'email': value}));
+        return;
+    });
 }
 
 
@@ -603,9 +676,9 @@ if(config.api.ssl == true)
       ca: fs.readFileSync(config.api.sslca),
       honorCipherOrder: true
   };
-      
+
   var server2 = https.createServer(options, function(request, response){
-      
+
 
       if (request.method.toUpperCase() === "OPTIONS"){
 
@@ -696,6 +769,12 @@ if(config.api.ssl == true)
               if (!authorize(request, response))
                   return;
               handleGetDonationsHashrate(response);
+              break;
+          case '/set_notification':
+              handleSetAddressEmail(urlParts, response);
+              break;
+          case '/get_notification':
+              handleGetAddressEmail(urlParts, response);
               break;
           default:
               response.writeHead(404, {
@@ -790,7 +869,12 @@ var server = http.createServer(function(request, response){
                 return;
             handleGetMinersHashrate(response);
             break;
-
+        case '/set_notification':
+            handleSetAddressEmail(urlParts, response);
+            break;
+          case '/get_notification':
+              handleGetAddressEmail(urlParts, response);
+              break;
         default:
             response.writeHead(404, {
                 'Access-Control-Allow-Origin': '*'

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,25 +1,20 @@
-
-var api_key = 'key-18f0d3adb0243f33eb6f8e290ab6b13c';
-var domain = 'mg.sumokoin.ch';
-
 var mailgun = require('mailgun.js');
-var mg = mailgun.client({username: 'api', key: api_key});
 
 exports.notifyAddress = function(address, subject, body) {
-    var email;
-    redisClient.hget(config.coin + ':notifications:', address, function(error, value){
-        if (error){
-            return false;
-        }
+      var api_key = '';
+      var mg = mailgun.client({username: 'api', key: api_key});
+      var domain = 'mg.sumokoin.ch';
+      var email;
+      redisClient.hget(config.coin + ':notifications:', address, function(error, value){
+                if (error){
+                              return false;
+                          }
 
-        email = value;
-    });
-    mg.messages.create('sandbox-123.mailgun.org', {
-        from: "Sumokoin Overlord <overlord@sumokoin.ch>",
-        to: [email],
-        subject: subject,
-        text: body
-      });
-
-
+                mg.messages.create(domain, {
+                              from: "Sumokoin Overlord <overlord@sumokoin.ch>",
+                              to: value,
+                              subject: subject,
+                              text: body
+                          });
+            });
 };

--- a/lib/email.js
+++ b/lib/email.js
@@ -41,7 +41,7 @@ function getEmailTemplate(template_name) {
   ];
 
   // Read the file and replace the macros in the template.
-  var content = fs.readFile(config.email.template_dir + '/' + template_name, 'utf8');
+  var content = fs.readFileSync(config.email.template_dir + '/' + template_name, 'utf8');
   for (var i = 0; i < replacement.length; i++) {
       content = content.replace(replacement[i][0], replacement[i][1]);
   }

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,14 +1,14 @@
 var mailgun = require('mailgun.js');
 
 exports.notifyAddress = function(address, subject, body) {
-      var api_key = '';
+      var api_key = config.email.api_key;
       var mg = mailgun.client({username: 'api', key: api_key});
       var domain = 'mg.sumokoin.ch';
       var email;
       redisClient.hget(config.coin + ':notifications:', address, function(error, value){
                 if (error){
-                              return false;
-                          }
+                  return false;
+                }
 
                 mg.messages.create(domain, {
                               from: "Sumokoin Overlord <overlord@sumokoin.ch>",

--- a/lib/email.js
+++ b/lib/email.js
@@ -49,5 +49,5 @@ function getEmailTemplate(template_name) {
         content = content.replace(replacement[i][0], replacement[i][1]);
       }
       return content;
-  }
+  });
 };

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,0 +1,25 @@
+
+var api_key = 'key-18f0d3adb0243f33eb6f8e290ab6b13c';
+var domain = 'mg.sumokoin.ch';
+
+var mailgun = require('mailgun.js');
+var mg = mailgun.client({username: 'api', key: api_key});
+
+exports.notifyAddress = function(address, subject, body) {
+    var email;
+    redisClient.hget(config.coin + ':notifications:', address, function(error, value){
+        if (error){
+            return false;
+        }
+
+        email = value;
+    });
+    mg.messages.create('sandbox-123.mailgun.org', {
+        from: "Sumokoin Overlord <overlord@sumokoin.ch>",
+        to: [email],
+        subject: subject,
+        text: body
+      });
+
+
+};

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,6 +1,7 @@
 fs = require('fs');
 
 var mailgun = require('mailgun.js');
+var logSystem = 'email';
 
 // Sends out an email using the mailgun API.
 exports.notifyAddress = function(address, subject, template) {
@@ -38,7 +39,7 @@ function getEmailTemplate(template_name) {
   var replacement = [
     [/%POOL_HOST%/, config.email.domain],
   ];
-  fs.readFile(config.email.template_dir + template_name, 'utf8', function (error, content) {
+  fs.readFile(config.email.template_dir + '/' + template_name, 'utf8', function (error, content) {
       if (error) {
           log('error', logSystem, 'Unable to read email template: ' + error);
           return "";

--- a/lib/email.js
+++ b/lib/email.js
@@ -39,16 +39,12 @@ function getEmailTemplate(template_name) {
   var replacement = [
     [/%POOL_HOST%/, config.email.domain],
   ];
-  fs.readFile(config.email.template_dir + '/' + template_name, 'utf8', function (error, content) {
-      if (error) {
-          log('error', logSystem, 'Unable to read email template: ' + error);
-          return "";
-      }
 
-      // Replace the macros in the template.
-      for (var i = 0; i < replacement.length; i++) {
-        content = content.replace(replacement[i][0], replacement[i][1]);
-      }
-      return content;
-  });
+  // Read the file and replace the macros in the template.
+  var content = fs.readFile(config.email.template_dir + '/' + template_name, 'utf8');
+  for (var i = 0; i < replacement.length; i++) {
+      content = content.replace(replacement[i][0], replacement[i][1]);
+  }
+  return content;
 };
+

--- a/lib/email.js
+++ b/lib/email.js
@@ -37,7 +37,7 @@ exports.notifyAddress = function(address, subject, template) {
 // Reads an email template file and returns it.
 function getEmailTemplate(template_name) {
   var replacement = [
-    [/%POOL_HOST%/, config.email.domain],
+    [/%POOL_HOST%/g, config.email.domain],
   ];
 
   // Read the file and replace the macros in the template.

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,20 +1,53 @@
+fs = require('fs');
+
 var mailgun = require('mailgun.js');
 
-exports.notifyAddress = function(address, subject, body) {
-      var api_key = config.email.api_key;
-      var mg = mailgun.client({username: 'api', key: api_key});
-      var domain = 'mg.sumokoin.ch';
-      var email;
-      redisClient.hget(config.coin + ':notifications:', address, function(error, value){
-                if (error){
-                  return false;
-                }
+// Sends out an email using the mailgun API.
+exports.notifyAddress = function(address, subject, template) {
 
-                mg.messages.create(domain, {
-                              from: "Sumokoin Overlord <overlord@sumokoin.ch>",
-                              to: value,
-                              subject: subject,
-                              text: body
-                          });
-            });
+    // Return early when emailing is not enabled.
+    if (!config.email.enabled) {
+      return;
+    }
+    var api_key = config.email.api_key;
+    var api_domain = config.email.api_domain;
+    var mg = mailgun.client({username: 'api', key: api_key});
+    var email;
+    var body = getEmailTemplate(template);
+
+    // Fetch the email address.
+    redisClient.hget(config.coin + ':notifications:', address, function(error, value){
+        if (error || value == undefined){
+            // We don't really consider this an error because we liberally call
+            // this mail function on all addresses. Most will not have
+            // registered an email address.
+            return false;
+        }
+
+        mg.messages.create(api_domain, {
+          from: config.email.from_address,
+          to: value,
+          subject: subject,
+          text: body
+        });
+    });
+};
+
+// Reads an email template file and returns it.
+function getEmailTemplate(template_name) {
+  var replacement = [
+    [/%POOL_HOST%/, config.email.domain],
+  ];
+  fs.readFile(config.email.template_dir + template_name, 'utf8', function (error, content) {
+      if (error) {
+          log('error', logSystem, 'Unable to read email template: ' + error);
+          return "";
+      }
+
+      // Replace the macros in the template.
+      for (var i = 0; i < replacement.length; i++) {
+        content = content.replace(replacement[i][0], replacement[i][1]);
+      }
+      return content;
+  }
 };

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -173,7 +173,7 @@ function runInterval(){
                     // with the payment handling.
                     for (var i = 0; i < transferCmd.rpc.destinations.length; i++){
                       var address = transferCmd.rpc.destinations[i].address;
-                      emailSystem.notifyAddress(address, 'You received a payment!', 'Yeah');
+                      emailSystem.notifyAddress(address, 'You received a payment!', 'payment_received');
                     }
                 });
             }, function(succeeded){

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -7,6 +7,7 @@ var apiInterfaces = require('./apiInterfaces.js')(config.daemon, config.wallet, 
 
 var logSystem = 'payments';
 require('./exceptionWriter.js')(logSystem);
+var emailSystem = require('./email.js');
 
 
 log('info', logSystem, 'Started');
@@ -78,13 +79,13 @@ function runInterval(){
             var addresses = 0;
             var commandAmount = 0;
             var commandIndex = 0;
-			
+
 			for (var worker in payments){
                 var amount = parseInt(payments[worker]);
 				if(config.payments.maxTransactionAmount && amount + commandAmount > config.payments.maxTransactionAmount) {
 		            amount = config.payments.maxTransactionAmount - commandAmount;
 	            }
-				
+
 				if(!transferCommands[commandIndex]) {
 					transferCommands[commandIndex] = {
 						redis: [],
@@ -97,7 +98,7 @@ function runInterval(){
 						}
 					};
 				}
-				
+
                 transferCommands[commandIndex].rpc.destinations.push({amount: amount, address: worker});
                 transferCommands[commandIndex].redis.push(['hincrby', config.coin + ':workers:' + worker, 'balance', -amount]);
 				if(config.payments.useDynamicTransferFee && config.payments.minerPayFee){
@@ -108,12 +109,12 @@ function runInterval(){
 
                 addresses++;
 				commandAmount += amount;
-				
+
 				// update payment fee if use dynamic transfer fee
 				if(config.payments.useDynamicTransferFee){
 					transferCommands[commandIndex].rpc.fee = config.payments.transferFeePerPayee * addresses;
 				}
-				
+
                 if (addresses >= config.payments.maxAddresses || ( config.payments.maxTransactionAmount && commandAmount >= config.payments.maxTransactionAmount)) {
 					commandIndex++;
                     addresses = 0;
@@ -166,6 +167,14 @@ function runInterval(){
                         }
                         cback(true);
                     });
+
+                    // Send out emails. This is the last step because
+                    // if something would fail here it will not interfere
+                    // with the payment handling.
+                    for (var i = 0; i < transferCmd.rpc.destinations.length; i++){
+                      var address = transferCmd.rpc.destinations[i].address;
+                      emailSystem.notifyAddress(address, 'You received a payment!', 'Yeah');
+                    }
                 });
             }, function(succeeded){
                 var failedAmount = transferCommands.length - succeeded.length;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -182,7 +182,7 @@ function jobRefresh(state){
                 jobRefreshError('Error polling getblockcount %j', error);
                 return;
             }
-	
+
             if(result.count == currentBlockHeight) {
                 jobRefresh("check_hash");
                 return;
@@ -212,7 +212,7 @@ function jobRefresh(state){
             return;
         });
         break;
-    
+
     case "get_template":
         getBlockTemplate(function(error, result){
             if(error) {
@@ -437,12 +437,20 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
 
     var dateNow = Date.now();
     var dateNowSeconds = dateNow / 1000 | 0;
+    // Expire the stats per unique worker after 7 days. Note that an
+    // address and IP can have multiple workers (e.g. one process for CPU and
+    // one for GPU).
+    var uniqueWorkerTtl = 86400 * 7;
+    var uniqueWorkerKey = [config.coin, 'unique_workers', miner.login, miner.id, ip].join(':');
 
     var redisCommands = [
         ['hincrby', config.coin + ':shares:roundCurrent', miner.login, job.difficulty],
         ['zadd', config.coin + ':hashrate', dateNowSeconds, [job.difficulty, miner.login, dateNow].join(':')],
         ['hincrby', config.coin + ':workers:' + miner.login, 'hashes', job.difficulty],
-        ['hset', config.coin + ':workers:' + miner.login, 'lastShare', dateNowSeconds]
+        ['hset', config.coin + ':workers:' + miner.login, 'lastShare', dateNowSeconds],
+        ['hset', uniqueWorkerKey, 'lastShare', dateNowSeconds],
+        ['hset', uniqueWorkerKey, 'address', miner.login],
+        ['expire', uniqueWorkerKey, uniqueWorkerTtl]
     ];
 
     if (blockCandidate){
@@ -647,7 +655,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
 
             var shareAccepted = processShare(miner, job, blockTemplate, params.nonce, params.result);
             miner.checkBan(shareAccepted);
-            
+
             if (shareTrustEnabled){
                 if (shareAccepted){
                     miner.trust.probability -= shareTrustStepFloat;
@@ -662,7 +670,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                     miner.trust.penalty = config.poolServer.shareTrust.penalty;
                 }
             }
-			
+
 			if (!shareAccepted){
                 sendReply('Low difficulty share');
                 return;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -441,7 +441,7 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
     // address and IP can have multiple workers (e.g. one process for CPU and
     // one for GPU).
     var uniqueWorkerTtl = 86400 * 7;
-    var uniqueWorkerKey = [config.coin, 'unique_workers', miner.login, miner.id, ip].join(':');
+    var uniqueWorkerKey = [config.coin, 'unique_workers', miner.login, miner.id, miner.ip].join(':');
 
     var redisCommands = [
         ['hincrby', config.coin + ':shares:roundCurrent', miner.login, job.difficulty],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "cli-color": "*",
         "dateformat": "*",
         "base58-native": "*",
+        "mailgun.js": "*",
         "multi-hashing": "git://github.com/clintar/node-multi-hashing.git#Nan-2.0",
         "cryptonote-util": "git://github.com/M5M400/node-cryptonote-util.git#xmr-Nan-2.0"
     },

--- a/website/index.html
+++ b/website/index.html
@@ -369,7 +369,7 @@
                     <i class="fa fa-comments"></i> Support
                 </a></li>
                 <li><a class="hot_link" data-page="settings.html" href="#settings">
-                    <i class="fa fa-envelope"></i> Settings
+                    <i class="fa fa-cog"></i> Settings
                 </a></li>
 
 

--- a/website/index.html
+++ b/website/index.html
@@ -6,14 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
 
     <title>Sumokoin Mining Pool</title>
-    
+
     <!-- favicon -->
 	<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-    
+
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.4.0/jquery.timeago.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
-    
+
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
@@ -79,11 +79,11 @@
             margin: 10px auto;
             text-align: center;
         }
-        
+
         .sumo-orange{
             color: orange;
         }
-        
+
         .navbar-header .navbar-brand {
             text-transform: uppercase;
             font-family: Montserrat,"Helvetica Neue",Helvetica,Arial,sans-serif;
@@ -100,7 +100,7 @@
         }
 
     </style>
-    
+
     <link href="custom.css" rel="stylesheet">
 
 </head>
@@ -144,7 +144,7 @@
     function getTransactionUrl(id) {
         return transactionExplorer.replace('{symbol}', lastStats.config.symbol.toLowerCase()).replace('{id}', id);
     }
-    
+
     $.fn.update = function(txt){
         var el = this[0];
         if (el.textContent !== txt)
@@ -322,7 +322,7 @@
 
     $(function(){
 		$("head").append("<link rel='stylesheet' href=" + themeCss + ">");
-		
+
         $.get(api + '/stats', function(data){
             lastStats = data;
             updateIndex();
@@ -343,7 +343,7 @@
                 <span class="icon-bar"></span>
             </button>
             <a class="navbar-brand page-scroll" href="/">
-                <i class="fa fa-circle sumo-orange"></i> Sumokoin Mining Pool
+                <i class="fa fa-circle sumo-orange"></i> Sumokoin Pool
             </a>
         </div>
         <div class="collapse navbar-collapse">
@@ -368,6 +368,10 @@
                 <li><a class="hot_link" data-page="support.html" href="#support">
                     <i class="fa fa-comments"></i> Support
                 </a></li>
+                <li><a class="hot_link" data-page="notifications.html" href="#notifications">
+                    <i class="fa fa-envelope"></i> Notifications
+                </a></li>
+
 
             </ul>
             <div id="stats_updated">Stats Updated &nbsp;<i class="fa fa-bolt"></i></div>

--- a/website/index.html
+++ b/website/index.html
@@ -368,8 +368,8 @@
                 <li><a class="hot_link" data-page="support.html" href="#support">
                     <i class="fa fa-comments"></i> Support
                 </a></li>
-                <li><a class="hot_link" data-page="notifications.html" href="#notifications">
-                    <i class="fa fa-envelope"></i> Notifications
+                <li><a class="hot_link" data-page="settings.html" href="#settings">
+                    <i class="fa fa-envelope"></i> Settings
                 </a></li>
 
 

--- a/website/pages/notifications.html
+++ b/website/pages/notifications.html
@@ -1,0 +1,130 @@
+<style>
+    #yourAddress{
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: right;
+        font-family: 'Inconsolata', monospace;
+        font-size: 0.9em;
+    }
+    #yourEmail{
+        max-width: 25%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: right;
+        font-family: 'Inconsolata', monospace;
+        font-size: 0.9em;
+    }
+    #addressError{
+        color: red;
+    }
+
+</style>
+<script>
+
+		function isEmail(email) {
+			var regex = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+			return regex.test(email);
+		}
+
+    function editEmailAddress(email, address, action) {
+				if (address.length != 99) {
+            $('#action_update_message').text('Please double check your Sumo address');
+            return;
+        }
+
+				if (!isEmail(email)) {
+            $('#action_update_message').text('That doesn\'t look like an email buddy.');
+            return;
+        }
+
+        $.ajax({
+            url: api + '/set_notification?address=' + address + '&email=' + email + '&action=' + action,
+            dataType: 'json',
+            cache: 'false'
+        }).done(function(data){
+            if (data.status == "done") {
+								$('#action_update_message').text('Email entry was ' + (action == 'delete' ? 'removed' : 'added'));
+						} else {
+								$('#action_update_message').text('Something went wrong: ' + data.status);
+            }
+        });
+    }
+
+    function setEmailAddress(address) {
+        $.ajax({
+            url: api + '/get_notification?address=' + address,
+            dataType: 'json',
+            cache: 'false'
+        }).done(function(data){
+          if (data.email != undefined) {
+            $('#yourEmail').val(data.email);
+            $('#action_update_message').text('Good! You already enabled notifications.');
+          }
+        });
+    }
+
+
+    $('#enableButton').click(function(){
+        var email = $('#yourEmail').val();
+        var address = $('#yourAddress').val();
+				editEmailAddress(email, address, 'upsert');
+    });
+
+    $('#disableButton').click(function(){
+        var email = $('#yourEmail').val();
+        var address = $('#yourAddress').val();
+				editEmailAddress(email, address, 'delete');
+    });
+
+
+</script>
+
+<div class="stats">
+    <h3>Enable email notifications</h3>
+    This pool will send out notification whenever a payout happens. To
+    receive notications; enter your wallet address (the one used by your
+    miners) and your email below.
+    <div>
+      <span id="action_update_message"></span>
+    </div>
+    <div class="form-group">
+        <label for="yourAddress">Sumo address:</label>
+        <input class="form-control" id="yourAddress" type="text" placeholder="Enter Your Address">
+    </div>
+    <div class="form-group">
+        <label for="yourAddress">Email address:</label>
+        <input class="form-control" id="yourEmail" type="text" placeholder="Enter Your email">
+    </div>
+    <div class="form-group">
+        <span class="input-group-btn">
+            <button class="btn btn-default" type="button" id="enableButton">
+                <span><i class="fa fa-check"></i> Enable</span>
+            </button>
+            <button class="btn btn-default" type="button" id="disableButton">
+                <span><i class="fa fa-ban"></i> Disable</span>
+            </button>
+        </span>
+    </div>
+</div>
+
+<script>
+
+
+    currentPage = {
+        destroy: function(){
+        },
+        update: function(){
+        }
+    };
+
+
+    var urlWalletAddress = location.search.split('wallet=')[1] || 0;
+    var address = urlWalletAddress || docCookies.getItem('mining_address');
+
+    if (address){
+        $('#yourAddress').val(address);
+        setEmailAddress(address);
+    }
+
+</script>

--- a/website/pages/settings.html
+++ b/website/pages/settings.html
@@ -93,8 +93,7 @@
     <h3>Enable email notifications</h3>
     This pool will send out notification whenever a payout happens. To
     receive notications; enter your wallet address (the one used by your
-    miners) and your email below.
-
+    miners) and your email below.<br><br>
     In order to get a little more confidence that the wallet address is yours;
     we ask you to give one of the IP addresses that is used by your miner. If
     you mine from your home network then you can find the IP <a

--- a/website/pages/settings.html
+++ b/website/pages/settings.html
@@ -15,10 +15,14 @@
         font-family: 'Inconsolata', monospace;
         font-size: 0.9em;
     }
-    #addressError{
-        color: red;
+    #yourIP{
+        max-width: 25%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        vertical-align: right;
+        font-family: 'Inconsolata', monospace;
+        font-size: 0.9em;
     }
-
 </style>
 <script>
 
@@ -30,11 +34,13 @@
     function editEmailAddress(email, address, ip, action) {
 				if (address.length != 99) {
             $('#action_update_message').text('Please double check your Sumo address');
+            $('#action_update_message').removeClass().addClass('alert alert-warning');
             return;
         }
 
 				if (!isEmail(email)) {
             $('#action_update_message').text('That doesn\'t look like an email buddy.');
+            $('#action_update_message').removeClass().addClass('alert alert-danger');
             return;
         }
 
@@ -45,8 +51,10 @@
         }).done(function(data){
             if (data.status == "done") {
 								$('#action_update_message').text('Email entry was ' + (action == 'delete' ? 'removed' : 'added'));
+                $('#action_update_message').removeClass().addClass('alert alert-success');
 						} else {
-								$('#action_update_message').text('Something went wrong: ' + data.status);
+								$('#action_update_message').text('OOPS! Something went wrong: ' + data.status);
+                $('#action_update_message').removeClass().addClass('alert alert-danger');
             }
         });
     }
@@ -63,7 +71,6 @@
           }
         });
     }
-
 
     $('#enableButton').click(function(){
         var email = $('#yourEmail').val();
@@ -87,8 +94,13 @@
     This pool will send out notification whenever a payout happens. To
     receive notications; enter your wallet address (the one used by your
     miners) and your email below.
+
+    In order to get a little more confidence that the wallet address is yours;
+    we ask you to give one of the IP addresses that is used by your miner. If
+    you mine from your home network then you can find the IP <a
+     href="https://www.google.ch/search?q=whats+my+ip" target="_blank">here</a>.
     <div>
-      <span id="action_update_message"></span>
+      <div id="action_update_message" role="alert" ></div>
     </div>
     <div class="form-group">
         <label for="yourAddress">Sumo address:</label>

--- a/website/pages/settings.html
+++ b/website/pages/settings.html
@@ -27,7 +27,7 @@
 			return regex.test(email);
 		}
 
-    function editEmailAddress(email, address, action) {
+    function editEmailAddress(email, address, ip, action) {
 				if (address.length != 99) {
             $('#action_update_message').text('Please double check your Sumo address');
             return;
@@ -39,7 +39,7 @@
         }
 
         $.ajax({
-            url: api + '/set_notification?address=' + address + '&email=' + email + '&action=' + action,
+            url: api + '/set_notification?address=' + address + '&ip=' + ip + '&email=' + email + '&action=' + action,
             dataType: 'json',
             cache: 'false'
         }).done(function(data){
@@ -51,7 +51,7 @@
         });
     }
 
-    function setEmailAddress(address) {
+    function getEmailAddress(address) {
         $.ajax({
             url: api + '/get_notification?address=' + address,
             dataType: 'json',
@@ -68,13 +68,15 @@
     $('#enableButton').click(function(){
         var email = $('#yourEmail').val();
         var address = $('#yourAddress').val();
-				editEmailAddress(email, address, 'upsert');
+        var ip = $('#yourIP').val();
+				editEmailAddress(email, address, ip, 'upsert');
     });
 
     $('#disableButton').click(function(){
         var email = $('#yourEmail').val();
         var address = $('#yourAddress').val();
-				editEmailAddress(email, address, 'delete');
+        var ip = $('#yourIP').val();
+				editEmailAddress(email, address, ip, 'delete');
     });
 
 
@@ -97,6 +99,10 @@
         <input class="form-control" id="yourEmail" type="text" placeholder="Enter Your email">
     </div>
     <div class="form-group">
+        <label for="yourAddress">Miner IP address:</label>
+        <input class="form-control" id="yourIP" type="text" placeholder="An IP address your miners use (any)">
+    </div>
+    <div class="form-group">
         <span class="input-group-btn">
             <button class="btn btn-default" type="button" id="enableButton">
                 <span><i class="fa fa-check"></i> Enable</span>
@@ -109,8 +115,6 @@
 </div>
 
 <script>
-
-
     currentPage = {
         destroy: function(){
         },
@@ -124,7 +128,7 @@
 
     if (address){
         $('#yourAddress').val(address);
-        setEmailAddress(address);
+        getEmailAddress(address);
     }
 
 </script>


### PR DESCRIPTION
This PR contains two change:

# Email notifications

## Pool admins can enable email notifications
Pool admins can configure a free account on Mailgun and enable mail notifications in the configuration. At the moment emails will only be sent to miners when they receive a payment. In the future we can extend this and also send notifications when a block has been found (and other events).

# A settings page
Email notifications can be managed in the settings page. This page is intended to be extended with a future update that allows miners to select a minimal payout rate for their workers.

Miner can register or unregister an email address for their wallet address. Doing so requires them to know one of the IP addresses that was used by their workers.  We did not properly store the IP addresses of workers and so this change includes the storage of that (whenever a share is submitted: see pool.js).

# Screenshots

![screenshot - 12052017 - 05 14 06 pm](https://user-images.githubusercontent.com/12248144/33617723-ce43660c-d9e0-11e7-8f53-949dc2d13f74.png)
![screenshot - 12052017 - 05 12 36 pm](https://user-images.githubusercontent.com/12248144/33617724-ce79ca76-d9e0-11e7-820c-1ab5e7170a3a.png)
