### PR TITLE
FIX: refactor the query for workers to use a set instead of using the KEYS command.

### DIFF
--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -15,9 +15,9 @@ log('info', logSystem, 'Started');
 function runInterval(){
     async.waterfall([
 
-        //Get worker keys
+        //Get workers from workers set.
         function(callback){
-            redisClient.keys(config.coin + ':workers:*', function(error, result) {
+            redisClient.smembers(config.coin + ':workers', function(error, result) {
                 if (error) {
                     log('error', logSystem, 'Error trying to get worker balances from redis %j', [error]);
                     callback(true);
@@ -28,9 +28,9 @@ function runInterval(){
         },
 
         //Get worker balances
-        function(keys, callback){
-            var redisCommands = keys.map(function(k){
-                return ['hget', k, 'balance'];
+        function(workers, callback){
+            var redisCommands = workers.map(function(k){
+                return ['hget', config.coin + ':workers:' + k, 'balance'];
             });
             redisClient.multi(redisCommands).exec(function(error, replies){
                 if (error){
@@ -40,10 +40,8 @@ function runInterval(){
                 }
                 var balances = {};
                 for (var i = 0; i < replies.length; i++){
-                    var parts = keys[i].split(':');
-                    var workerId = parts[parts.length - 1];
+                    var workerId = workers[i];
                     balances[workerId] = parseInt(replies[i]) || 0
-
                 }
                 callback(null, balances);
             });

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -582,8 +582,6 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             var minerId = utils.uid();
             miner = new Miner(minerId, login, params.pass, ip, difficulty, noRetarget, pushMessage);
             connectedMiners[minerId] = miner;
-            // TODO: make sure this works, or else they won't get paid out.
-            // Balance will still exist, thankfully.
             redisClient.sadd(config.coin + ':workers', miner.login);
             
             sendReply(null, {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -582,6 +582,10 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             var minerId = utils.uid();
             miner = new Miner(minerId, login, params.pass, ip, difficulty, noRetarget, pushMessage);
             connectedMiners[minerId] = miner;
+            // TODO: make sure this works, or else they won't get paid out.
+            // Balance will still exist, thankfully.
+            redisClient.sadd(config.coin + ':workers', miner.login);
+            
             sendReply(null, {
                 id: minerId,
                 job: miner.getJob(),


### PR DESCRIPTION
 When generating the list of workers to do payouts, cryptonote-pool uses the KEYS command. This can cause the redis database to lockup and also takes a lot of CPU.

This PR changes that and uses instead a SET with all the workers.

This should with issue #7.